### PR TITLE
Preserve alias input during session updates

### DIFF
--- a/src/app/planning-session/planning-session.component.ts
+++ b/src/app/planning-session/planning-session.component.ts
@@ -168,9 +168,14 @@ export class PlanningSessionComponent implements OnInit, OnDestroy {
       this.currentVote = this.session.participants[this.userId].vote;
       this.aliasSet = true;
     } else {
-      // If user is not a participant, check sessionStorage for a saved alias
-      const savedAlias = sessionStorage.getItem(this.getAliasStorageKey());
-      this.alias = savedAlias || '';
+      // If user is not a participant yet, don't wipe out whatever the user has
+      // currently typed. Only populate from sessionStorage on first load when
+      // the input is empty. Subsequent realtime updates should not clear the
+      // field while the user is entering their alias.
+      if (!this.alias) {
+        const savedAlias = sessionStorage.getItem(this.getAliasStorageKey());
+        this.alias = savedAlias || '';
+      }
       this.aliasSet = false;
     }
     if (this.isFacilitator) {


### PR DESCRIPTION
## Summary
- keep player alias text while realtime updates occur
- only load stored alias from session storage when input is empty

## Testing
- `npm test` *(fails: Cannot determine project or target for command.)*

------
https://chatgpt.com/codex/tasks/task_e_68aeca3874788328937ad69c5584fd04