### PR TITLE
Remove coffee vote and make question mark passive

### DIFF
--- a/src/app/planning-session/planning-session.component.html
+++ b/src/app/planning-session/planning-session.component.html
@@ -77,7 +77,7 @@
                   >
                 </div>
               </div>
-              <p *ngIf="averageVote > 0" class="mt-4 text-xl">
+              <p *ngIf="averageVote !== null" class="mt-4 text-xl">
                 Average: {{ averageVote | number: "1.2-2" }}
               </p>
             </div>

--- a/src/app/planning-session/planning-session.component.ts
+++ b/src/app/planning-session/planning-session.component.ts
@@ -25,7 +25,7 @@ export class PlanningSessionComponent implements OnInit, OnDestroy {
   jiraTicket = '';
   loading = true; // We will manage this carefully
 
-  votingCards = ['0', '1', '2', '3', '5', '8', '13', '21', '?', '☕'];
+  votingCards = ['0', '1', '2', '3', '5', '8', '13', '21', '?'];
   private sessionSub!: RealtimeChannel;
 
   constructor(
@@ -161,12 +161,15 @@ export class PlanningSessionComponent implements OnInit, OnDestroy {
     return votes.reduce((acc, vote) => ({...acc, [vote]: (acc[vote] || 0) + 1}), {} as { [key: string]: number });
   }
 
-  get averageVote(): number {
-    if (!this.session) return 0;
+  get averageVote(): number | null {
+    if (!this.session) return null;
     const numericVotes = this.participantsArray
-      .map(([, p]) => Number(p.vote))
-      .filter(v => !isNaN(v));
-    return numericVotes.length > 0 ? numericVotes.reduce((sum, v) => sum + v, 0) / numericVotes.length : 0;
+      .map(([, p]) => p.vote)
+      .filter((v): v is string => v !== null && !isNaN(Number(v)))
+      .map(v => Number(v));
+    return numericVotes.length > 0
+      ? numericVotes.reduce((sum, v) => sum + v, 0) / numericVotes.length
+      : null;
   }
 
   updateLocalStateFromSession() {


### PR DESCRIPTION
## Summary
- remove coffee cup option from voting cards
- ensure average score ignores non-numeric votes and display only when applicable

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a07f2ca48328b176b8fbc3090f01